### PR TITLE
fix circup install command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install pixelbuf
+    circup install adafruit_pixelbuf
 
 Or the following command to update an existing version:
 


### PR DESCRIPTION
```python
Searching for dependencies for: ['pixelbuf']   
WARNING:
        pixelbuf is not a known CircuitPython library.
```

My guess seemed to work OK

```python
(circuitpython) PS D:\> circup install adafruit_pixelbuf
Found device at D:\, running CircuitPython 7.3.2.
Searching for dependencies for: ['adafruit_pixelbuf']
Ready to install: ['adafruit_pixelbuf']
```