### PR TITLE
Fixed docstring of method `fill`.

### DIFF
--- a/adafruit_pixelbuf.py
+++ b/adafruit_pixelbuf.py
@@ -206,6 +206,7 @@ class PixelBuf:  # pylint: disable=too-many-instance-attributes
     def fill(self, color: ColorUnion):
         """
         Fills the given pixelbuf with the given color.
+
         :param pixelbuf: A pixel object.
         :param color: Color to set.
         """


### PR DESCRIPTION
Fixed the docstring of the `fill` method, so that its parameters are rendered properly in the documentation.
Resolves #11 